### PR TITLE
Fix git tracking the .pnpm-store*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 
 # dependencies
 /node_modules
-/.pnp
+/.pnp*
 .pnp.js
 .yarn/install-state.gz
 package-lock.json


### PR DESCRIPTION
Git is tracking the .pnpm-store* with over 10000 files. We don't want that