### PR TITLE
Fix username name handling

### DIFF
--- a/src/services/parsing/__tests__/metaHandlers.usernameFallback.test.ts
+++ b/src/services/parsing/__tests__/metaHandlers.usernameFallback.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import { DonationErrors } from "@services/errors";
+
+type ZipEntryLike = { filename: string };
+
+async function setupModule(profileContentFactory: () => string) {
+  const mockExtractEntriesFromZips = jest
+    .fn()
+    .mockResolvedValue([{ filename: "personal_information.json" }, { filename: "inbox/test_thread/message_1.json" }]);
+
+  const mockGetEntryText = jest.fn(async (entry: ZipEntryLike) => {
+    if (entry.filename.includes("message")) {
+      return JSON.stringify({ thread_path: "inbox/test_thread", participants: [], messages: [] });
+    }
+    return profileContentFactory();
+  });
+
+  const mockDeIdentify = jest.fn(() => ({
+    anonymizedConversations: [],
+    participantNamesToPseudonyms: {},
+    chatMappingToShow: new Map()
+  }));
+
+  jest.doMock("@services/parsing/shared/aliasConfig", () => require("@services/__mocks__/aliasConfigMock"));
+  jest.doMock("@services/parsing/shared/zipExtraction", () => ({
+    extractEntriesFromZips: (...args: unknown[]) => mockExtractEntriesFromZips(...args),
+    getEntryText: (...args: unknown[]) => mockGetEntryText(...args),
+    isMatchingEntry: (entry: ZipEntryLike, pattern: string) => entry.filename.includes(pattern)
+  }));
+  jest.doMock("@services/parsing/meta/deIdentify", () => ({
+    __esModule: true,
+    default: (...args: unknown[]) => mockDeIdentify(...args)
+  }));
+
+  const { handleInstagramZipFiles } = await import("@services/parsing/meta/metaHandlers");
+
+  return {
+    handleInstagramZipFiles,
+    mockDeIdentify
+  };
+}
+
+describe("metaHandlers Instagram donor name extraction", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("falls back to Username when Name is missing", async () => {
+    const { handleInstagramZipFiles, mockDeIdentify } = await setupModule(() =>
+      JSON.stringify({
+        profile_user: [
+          {
+            string_map_data: {
+              Username: { value: "username_only" }
+            }
+          }
+        ]
+      })
+    );
+
+    await handleInstagramZipFiles([new File(["x"], "dummy.zip")]);
+
+    expect(mockDeIdentify).toHaveBeenCalled();
+    expect(mockDeIdentify.mock.calls[0][2]).toBe("username_only");
+  });
+
+  it("returns NoDonorNameFound when both Name and Username are missing", async () => {
+    const { handleInstagramZipFiles } = await setupModule(() =>
+      JSON.stringify({
+        profile_user: [
+          {
+            string_map_data: {}
+          }
+        ]
+      })
+    );
+
+    await expect(handleInstagramZipFiles([new File(["x"], "dummy.zip")])).rejects.toMatchObject({
+      reason: DonationErrors.NoDonorNameFound,
+      message: DonationErrors.NoDonorNameFound
+    });
+  });
+});

--- a/src/services/parsing/meta/metaHandlers.ts
+++ b/src/services/parsing/meta/metaHandlers.ts
@@ -54,8 +54,9 @@ const extractDonorNameFromFacebookProfile = (profileText: string): string => {
 
 const extractDonorNameFromInstagramProfile = (profileText: string): string => {
   interface ProfileUser {
-    string_map_data: {
-      Name: { value: string };
+    string_map_data?: {
+      Name?: { value?: string };
+      Username?: { value?: string };
     };
   }
 
@@ -63,9 +64,15 @@ const extractDonorNameFromInstagramProfile = (profileText: string): string => {
     profile_user: ProfileUser[];
   }
 
-  const profileJson: ProfileInfo = JSON.parse(profileText);
+  let profileJson: ProfileInfo;
+  try {
+    profileJson = JSON.parse(profileText);
+  } catch {
+    throw DonationValidationError(DonationErrors.NoDonorNameFound);
+  }
 
-  const name = profileJson?.profile_user?.[0]?.string_map_data?.Name?.value;
+  const stringMap = profileJson?.profile_user?.[0]?.string_map_data;
+  const name = stringMap?.Name?.value ?? stringMap?.Username?.value;
   if (name) return decode(name);
 
   throw DonationValidationError(DonationErrors.NoDonorNameFound);
@@ -105,6 +112,10 @@ async function handleMetaZipFiles(
     // Process the extracted data
     return deIdentify(parsedConversations, audioEntries, donorName, dataSourceValue);
   } catch (error) {
+    // Keep actionable validation reasons for the UI instead of collapsing to UnknownError.
+    if (error && typeof error === "object" && "reason" in error) {
+      throw error;
+    }
     throw DonationValidationError(DonationErrors.UnknownError);
   }
 }


### PR DESCRIPTION
Implements the same fix as in dona v1 where the username and name was crashing the application. 
Fix is the username as fallback if the name value equals null and also throwing and exception if neither name nor username is present