### PR TITLE
Finish duplicate donation feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,15 @@ POSTGRES_HOST_PORT=5432
 DATABASE_URL=postgres://dona:password@localhost:5432/dona
 
 # Config for survey redirects
+DEMO_MODE=false
 DONOR_ID_INPUT_METHOD=automated # Options: automated, showid, manually
 DONOR_SURVEY_ENABLED=false
 FEEDBACK_SURVEY_ENABLED=false
 DONOR_SURVEY_LINK=https://survey.mbp.tf.uni-bielefeld.de/index.php?r=survey/index&sid=453492
 FEEDBACK_SURVEY_LINK=https://survey.mbp.tf.uni-bielefeld.de/index.php?r=survey/&sid=158878
+
+# Duplicate donation check
+NEXT_PUBLIC_DUPLICATE_DONATION_CHECK_ENABLED=true
+DUPLICATE_DONATION_CHECK_ENABLED=true
+NEXT_PUBLIC_MIN_MESSAGES_FOR_DUPLICATE_CHECK=100
+DUPLICATE_CHECK_EXCEPTION_HASHES_CSV_PATH=public/documents/sample-data/duplicate-check-exceptions.csv

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Create a `.env` file in the project root, by copying and renaming `.env.example`
 - `DATABASE_URL` — Postgres connection string used by the app (compose sets this automatically for the containerized app)
 - `DONOR_ID_INPUT_METHOD`, `DONOR_SURVEY_ENABLED`, `FEEDBACK_SURVEY_ENABLED`, `DONOR_SURVEY_LINK`, `FEEDBACK_SURVEY_LINK` — feature flags/links
 - `DEMO_MODE` — set to `true` to run Dona in demo mode (no data ingestion, demo notices in flow, sample data downloads on feedback page, and no final survey CTA)
+- `NEXT_PUBLIC_DUPLICATE_DONATION_CHECK_ENABLED` — set to `false` to skip duplicate-donation rejection during upload (default: `true`)
+- `DUPLICATE_DONATION_CHECK_ENABLED` — server-side toggle for duplicate checking, should usually match `NEXT_PUBLIC_DUPLICATE_DONATION_CHECK_ENABLED` (default: `true`)
+- `NEXT_PUBLIC_MIN_MESSAGES_FOR_DUPLICATE_CHECK` — minimum combined text+audio messages per conversation before a hash is computed (default: `100`)
+- `DUPLICATE_CHECK_EXCEPTION_HASHES_CSV_PATH` — path to a CSV containing allowed duplicate hashes (default: `public/documents/sample-data/duplicate-check-exceptions.csv`)
 - Ports (configurable):
   - `APP_PORT` — host port to bind the web app to in docker-compose (default: `3000`)
   - `APP_INTERNAL_PORT` — container/internal port the Next.js server listens on (default: `3000`)
@@ -100,6 +104,15 @@ PORT=3001 pnpm dev
 ```bash
 pnpm test
 ```
+
+## Duplicate-Check Exception Workflow
+
+To allow known test exports without disabling duplicate checking globally:
+
+1. Upload the test export in Dona (Data Donation page).
+2. Click **Download Duplicate-Check CSV** after parsing finishes.
+3. Add the CSV rows (or just the `conversationHash` column) to the file at `DUPLICATE_CHECK_EXCEPTION_HASHES_CSV_PATH`.
+4. Restart the app so new environment/config values are reloaded.
 
 ### Checking logs and data
 

--- a/public/documents/sample-data/duplicate-check-exceptions.csv
+++ b/public/documents/sample-data/duplicate-check-exceptions.csv
@@ -1,0 +1,3 @@
+conversationHash,dataSource,conversationPseudonym,textMessages,audioMessages,totalMessages,minTimestamp,maxTimestamp
+# Add one row per allowed test conversation hash.
+# Only the first column (conversationHash) is required by duplicate checking.

--- a/src/app/__tests__/dataDonationActions.duplicateCheckConfig.test.ts
+++ b/src/app/__tests__/dataDonationActions.duplicateCheckConfig.test.ts
@@ -1,0 +1,70 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+import { createMockDbClient } from "@/app/__tests__/mockDbClient";
+
+describe("donation actions - duplicate check config", () => {
+  const originalServerToggle = process.env.DUPLICATE_DONATION_CHECK_ENABLED;
+  const originalPublicToggle = process.env.NEXT_PUBLIC_DUPLICATE_DONATION_CHECK_ENABLED;
+  const originalCsvPath = process.env.DUPLICATE_CHECK_EXCEPTION_HASHES_CSV_PATH;
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.DUPLICATE_DONATION_CHECK_ENABLED = originalServerToggle;
+    process.env.NEXT_PUBLIC_DUPLICATE_DONATION_CHECK_ENABLED = originalPublicToggle;
+    process.env.DUPLICATE_CHECK_EXCEPTION_HASHES_CSV_PATH = originalCsvPath;
+    jest.resetModules();
+  });
+
+  test("checkForDuplicateConversations can be disabled via config", async () => {
+    process.env.DUPLICATE_DONATION_CHECK_ENABLED = "false";
+    process.env.NEXT_PUBLIC_DUPLICATE_DONATION_CHECK_ENABLED = "false";
+
+    const { checkForDuplicateConversations } = await import("@/app/data-donation/actions");
+    const throwingClient = createMockDbClient({
+      query: {
+        conversations: {
+          findMany: () => {
+            throw new Error("findMany should not be called when duplicate check is disabled");
+          }
+        }
+      }
+    }).client;
+
+    const res = await checkForDuplicateConversations(["a".repeat(64)], throwingClient);
+
+    expect(res.success).toBe(true);
+    expect(res.data).toEqual({ hasDuplicates: false });
+  });
+
+  test("checkForDuplicateConversations ignores hashes configured as exceptions", async () => {
+    process.env.DUPLICATE_DONATION_CHECK_ENABLED = "true";
+    process.env.NEXT_PUBLIC_DUPLICATE_DONATION_CHECK_ENABLED = "true";
+
+    const hash = "a".repeat(64);
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dona-duplicate-check-"));
+    const csvPath = path.join(tempDir, "exceptions.csv");
+    await fs.writeFile(csvPath, `conversationHash\n${hash}\n`, "utf8");
+    process.env.DUPLICATE_CHECK_EXCEPTION_HASHES_CSV_PATH = csvPath;
+
+    const { checkForDuplicateConversations } = await import("@/app/data-donation/actions");
+    const overriding = createMockDbClient({
+      query: {
+        conversations: {
+          findMany: jest.fn(async (_opts?: any): Promise<any[]> => [])
+        }
+      }
+    } as any).client;
+
+    const res = await checkForDuplicateConversations([hash], overriding);
+
+    expect(overriding.query!.conversations!.findMany).not.toHaveBeenCalled();
+    expect(res.success).toBe(true);
+    expect(res.data).toEqual({ hasDuplicates: false });
+  });
+});

--- a/src/app/data-donation/actions.ts
+++ b/src/app/data-donation/actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import fs from "fs/promises";
+import path from "path";
 import { eq } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 
@@ -8,12 +10,40 @@ import { conversationParticipants, conversations, donations, graphData, messages
 import { DbClient } from "@/db/types";
 import { NewConversation, NewMessage, NewMessageAudio } from "@models/persisted";
 import { Conversation, DonationStatus } from "@models/processed";
+import { parseDuplicateCheckExceptionHashesCsv } from "@/services/duplicateCheckExceptions";
 import { DonationStats } from "@services/donationStats";
 import { DonationErrors, DonationProcessingError, SerializedDonationError } from "@services/errors";
 
 const MAX_MESSAGES_PER_TX = 10000; // max messages (text + audio) per DB transaction
 const BULK_CHUNK = 2000; // chunk size for large bulk inserts
 const isDemoMode = process.env.DEMO_MODE === "true";
+const isDuplicateCheckEnabled =
+  process.env.DUPLICATE_DONATION_CHECK_ENABLED !== "false" && process.env.NEXT_PUBLIC_DUPLICATE_DONATION_CHECK_ENABLED !== "false";
+
+let cachedExceptionHashes: Set<string> | null = null;
+
+async function loadDuplicateCheckExceptionHashes(): Promise<Set<string>> {
+  if (cachedExceptionHashes) {
+    return cachedExceptionHashes;
+  }
+
+  const configuredPath =
+    process.env.DUPLICATE_CHECK_EXCEPTION_HASHES_CSV_PATH || "public/documents/sample-data/duplicate-check-exceptions.csv";
+  const csvPath = path.isAbsolute(configuredPath) ? configuredPath : path.join(process.cwd(), configuredPath);
+
+  try {
+    const csv = await fs.readFile(csvPath, "utf8");
+    cachedExceptionHashes = parseDuplicateCheckExceptionHashesCsv(csv);
+    console.log(`[DONATION] Loaded ${cachedExceptionHashes.size} duplicate-check exception hash(es) from ${csvPath}`);
+    return cachedExceptionHashes;
+  } catch (error: any) {
+    if (error?.code !== "ENOENT") {
+      console.warn(`[DONATION] Could not read duplicate-check exception file (${csvPath}): ${error?.message || error}`);
+    }
+    cachedExceptionHashes = new Set<string>();
+    return cachedExceptionHashes;
+  }
+}
 
 interface ActionResult<T = unknown> {
   success: boolean;
@@ -274,7 +304,7 @@ export async function checkForDuplicateConversations(
   hashes: string[],
   dbClient: DbClient = db
 ): Promise<ActionResult<{ hasDuplicates: boolean }>> {
-  if (isDemoMode) {
+  if (isDemoMode || !isDuplicateCheckEnabled) {
     return { success: true, data: { hasDuplicates: false } };
   }
 
@@ -282,16 +312,24 @@ export async function checkForDuplicateConversations(
 
   try {
     // Filter out null/empty hashes
-    const validHashes = hashes.filter(h => h && h.length > 0);
+    const validHashes = hashes.filter(h => h && h.length > 0).map(h => h.toLowerCase());
 
     if (validHashes.length === 0) {
       console.log(`[DONATION] ✅ checkForDuplicateConversations: no valid hashes to check`);
       return { success: true, data: { hasDuplicates: false } };
     }
 
+    const exceptionHashes = await loadDuplicateCheckExceptionHashes();
+    const hashesToCheck = validHashes.filter(hash => !exceptionHashes.has(hash));
+
+    if (hashesToCheck.length === 0) {
+      console.log(`[DONATION] ✅ checkForDuplicateConversations: all hashes are covered by configured exceptions`);
+      return { success: true, data: { hasDuplicates: false } };
+    }
+
     // Query database for existing conversations with these hashes
     const existingConversations = await dbClient.query.conversations.findMany({
-      where: (conversations: any, { inArray }: { inArray: any }) => inArray(conversations.conversationHash, validHashes),
+      where: (conversations: any, { inArray }: { inArray: any }) => inArray(conversations.conversationHash, hashesToCheck),
       columns: {
         conversationHash: true
       }

--- a/src/components/DonationDataSelector.tsx
+++ b/src/components/DonationDataSelector.tsx
@@ -2,6 +2,7 @@
 
 import Alert, { AlertProps } from "@mui/material/Alert";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 
 import { FileList, FileUploadButton, RemoveButton } from "@components/DonationComponents";
 import styled from "@mui/material/styles/styled";
@@ -12,6 +13,7 @@ import { CONFIG } from "@/config";
 import { useRichTranslations } from "@/hooks/useRichTranslations";
 import { anonymizeData } from "@/services/anonymization";
 import { computeConversationHash, shouldHashConversation } from "@/services/conversationHash";
+import { collectDuplicateCheckFeatures, duplicateCheckFeaturesToCsv } from "@/services/duplicateCheckFeatures";
 import { checkForDuplicateConversations } from "@/app/data-donation/actions";
 import AnonymizationPreview from "@components/AnonymizationPreview";
 import DateRangePicker from "@components/DateRangePicker";
@@ -41,6 +43,7 @@ const DonationDataSelector: React.FC<DonationDataSelectorProps> = ({
   const donation = useRichTranslations("donation");
   const acceptedFileTypes =
     dataSourceValue == DataSourceValue.WhatsApp ? ".txt, .zip" : dataSourceValue == DataSourceValue.IMessage ? ".db" : ".zip";
+  const duplicateCheckEnabled = CONFIG.DUPLICATE_DONATION_CHECK_ENABLED;
 
   // States
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
@@ -69,9 +72,8 @@ const DonationDataSelector: React.FC<DonationDataSelectorProps> = ({
       const result = await anonymizeData(dataSourceValue, files);
 
       // Step 2: Compute hashes and check for duplicates with server
-      setLoadingStep(2);
       const conversationsWithHashes = result.anonymizedConversations.map(convo => {
-        const hash = shouldHashConversation(convo) ? computeConversationHash(convo) : null;
+        const hash = shouldHashConversation(convo, CONFIG.MIN_MESSAGES_FOR_DUPLICATE_CHECK) ? computeConversationHash(convo) : null;
         return {
           ...convo,
           conversationHash: hash
@@ -79,7 +81,8 @@ const DonationDataSelector: React.FC<DonationDataSelectorProps> = ({
       });
 
       const hashes = conversationsWithHashes.map(convo => convo.conversationHash).filter((hash): hash is string => hash !== null);
-      if (hashes.length > 0) {
+      if (duplicateCheckEnabled && hashes.length > 0) {
+        setLoadingStep(2);
         const duplicateCheck = await checkForDuplicateConversations(hashes);
         if (!duplicateCheck.success) {
           throw duplicateCheck.error;
@@ -137,6 +140,24 @@ const DonationDataSelector: React.FC<DonationDataSelectorProps> = ({
     }
   };
 
+  const handleDownloadDuplicateCheckCsv = () => {
+    if (!anonymizationResult) {
+      return;
+    }
+
+    const features = collectDuplicateCheckFeatures(anonymizationResult.anonymizedConversations, CONFIG.MIN_MESSAGES_FOR_DUPLICATE_CHECK);
+    const csvContent = duplicateCheckFeaturesToCsv(features);
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `duplicate-check-features-${String(dataSourceValue).toLowerCase()}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <Box>
       <Typography sx={{ fontWeight: "bold" }}>{donation.t("selectData.instruction")}</Typography>
@@ -162,9 +183,11 @@ const DonationDataSelector: React.FC<DonationDataSelectorProps> = ({
       {isLoading && (
         <LoadingSpinner
           message={
-            loadingStep === 1
-              ? donation.t("anonymisation.processingStep", { step: "1/2" })
-              : donation.t("anonymisation.checkingDuplicatesStep", { step: "2/2" })
+            !duplicateCheckEnabled
+              ? donation.t("anonymisation.processingStep", { step: "1/1" })
+              : loadingStep === 1
+                ? donation.t("anonymisation.processingStep", { step: "1/2" })
+                : donation.t("anonymisation.checkingDuplicatesStep", { step: "2/2" })
           }
         />
       )}
@@ -172,6 +195,9 @@ const DonationDataSelector: React.FC<DonationDataSelectorProps> = ({
       {/* Display anonymized data */}
       {!error && !isLoading && anonymizationResult && filteredConversations && (
         <Box sx={{ my: 3 }}>
+          <Button variant="outlined" sx={{ mb: 2 }} onClick={handleDownloadDuplicateCheckCsv}>
+            Download Duplicate-Check CSV
+          </Button>
           {dataSourceValue !== DataSourceValue.Facebook && dataSourceValue !== DataSourceValue.Instagram && (
             <>
               <DateRangePicker calculatedRange={calculatedRange} setSelectedRange={handleDateRangeChange} />

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,12 +8,32 @@ export const localeNames: Record<Locale, string> = {
 };
 export const defaultLocale: Locale = "en";
 
+const parseBooleanEnv = (value: string | undefined, defaultValue: boolean): boolean => {
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  return value.toLowerCase() === "true";
+};
+
+const parseNumberEnv = (value: string | undefined, defaultValue: number): number => {
+  if (!value) {
+    return defaultValue;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+};
+
 export const CONFIG = {
   MIN_DONATION_TIME_PERIOD_MONTHS: 6,
 
   MIN_CHATS_FOR_DONATION: 5,
   MIN_MESSAGES_PER_CHAT: 100,
   MIN_CONTACTS_PER_CHAT: 2,
+
+  DUPLICATE_DONATION_CHECK_ENABLED: parseBooleanEnv(process.env.NEXT_PUBLIC_DUPLICATE_DONATION_CHECK_ENABLED, true),
+  MIN_MESSAGES_FOR_DUPLICATE_CHECK: parseNumberEnv(process.env.NEXT_PUBLIC_MIN_MESSAGES_FOR_DUPLICATE_CHECK, 100),
 
   MAX_FEEDBACK_CHATS: 10,
   MIN_FEEDBACK_CHATS: 3,

--- a/src/services/duplicateCheckExceptions.ts
+++ b/src/services/duplicateCheckExceptions.ts
@@ -1,0 +1,25 @@
+export function parseDuplicateCheckExceptionHashesCsv(csvContent: string): Set<string> {
+  const hashes = new Set<string>();
+
+  csvContent.split(/\r?\n/).forEach((line, idx) => {
+    const trimmed = line.trim();
+
+    if (!trimmed || trimmed.startsWith("#")) {
+      return;
+    }
+
+    const firstColumn = trimmed.split(",")[0]?.trim().replace(/^"|"$/g, "");
+    if (!firstColumn || firstColumn.toLowerCase() === "conversationhash") {
+      return;
+    }
+
+    if (!/^[a-f0-9]{64}$/i.test(firstColumn)) {
+      console.warn(`[DONATION] Skipping invalid exception hash on line ${idx + 1}: ${firstColumn}`);
+      return;
+    }
+
+    hashes.add(firstColumn.toLowerCase());
+  });
+
+  return hashes;
+}

--- a/src/services/duplicateCheckFeatures.ts
+++ b/src/services/duplicateCheckFeatures.ts
@@ -1,0 +1,88 @@
+import { Conversation } from "@models/processed";
+
+import { computeConversationHash, shouldHashConversation } from "@/services/conversationHash";
+
+export interface DuplicateCheckFeature {
+  conversationHash: string;
+  dataSource: string;
+  conversationPseudonym: string;
+  textMessages: number;
+  audioMessages: number;
+  totalMessages: number;
+  minTimestamp: number | null;
+  maxTimestamp: number | null;
+}
+
+function quoteCsv(value: string | number | null): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  const text = String(value);
+  if (!/[",\n]/.test(text)) {
+    return text;
+  }
+
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+export function collectDuplicateCheckFeatures(conversations: Conversation[], minMessages: number): DuplicateCheckFeature[] {
+  return conversations
+    .map(conversation => {
+      if (!shouldHashConversation(conversation, minMessages)) {
+        return null;
+      }
+
+      const hash = conversation.conversationHash || computeConversationHash(conversation);
+      if (!hash) {
+        return null;
+      }
+
+      const timestamps = [
+        ...(conversation.messages || []).map(message => message.timestamp),
+        ...(conversation.messagesAudio || []).map(message => message.timestamp)
+      ];
+      const textMessages = conversation.messages?.length || 0;
+      const audioMessages = conversation.messagesAudio?.length || 0;
+
+      return {
+        conversationHash: hash,
+        dataSource: conversation.dataSource,
+        conversationPseudonym: conversation.conversationPseudonym,
+        textMessages,
+        audioMessages,
+        totalMessages: textMessages + audioMessages,
+        minTimestamp: timestamps.length > 0 ? Math.min(...timestamps) : null,
+        maxTimestamp: timestamps.length > 0 ? Math.max(...timestamps) : null
+      };
+    })
+    .filter((feature): feature is DuplicateCheckFeature => feature !== null);
+}
+
+export function duplicateCheckFeaturesToCsv(features: DuplicateCheckFeature[]): string {
+  const header = [
+    "conversationHash",
+    "dataSource",
+    "conversationPseudonym",
+    "textMessages",
+    "audioMessages",
+    "totalMessages",
+    "minTimestamp",
+    "maxTimestamp"
+  ].join(",");
+
+  const rows = features.map(feature =>
+    [
+      quoteCsv(feature.conversationHash),
+      quoteCsv(feature.dataSource),
+      quoteCsv(feature.conversationPseudonym),
+      quoteCsv(feature.textMessages),
+      quoteCsv(feature.audioMessages),
+      quoteCsv(feature.totalMessages),
+      quoteCsv(feature.minTimestamp),
+      quoteCsv(feature.maxTimestamp)
+    ].join(",")
+  );
+
+  return [header, ...rows].join("\n");
+}

--- a/src/services/validateEnv.mjs
+++ b/src/services/validateEnv.mjs
@@ -11,7 +11,13 @@ const envSchema = z.object({
 
 export const validateEnv = () => {
   try {
-    const parsedEnv = envSchema.parse(process.env);
+    // Docker/Compose can inject empty strings for unset variables (e.g., DEMO_MODE="").
+    // Treat empty strings as undefined so zod defaults can be applied.
+    const normalizedEnv = Object.fromEntries(
+      Object.entries(process.env).map(([key, value]) => [key, value === "" ? undefined : value])
+    );
+
+    const parsedEnv = envSchema.parse(normalizedEnv);
 
     // Convert non-string values to strings for Next.js compatibility
     return Object.fromEntries(Object.entries(parsedEnv).map(([key, value]) => [key, String(value)]));


### PR DESCRIPTION
Duplicate donation checking can now be enabled/disabled via environment config.
 Exceptions are implemented as a hash allowlist loaded from a CSV file path in config. During duplicate validation, hashes in that CSV are filtered out before DB collision lookup.
 Dona now provides an export of duplicate-check features as CSV after parsing.
This CSV includes conversationHash plus useful metadata.
For exception matching, only conversationHash is required; other columns are optional/contextual.